### PR TITLE
utils/hlir.py: check for string equality instead of instance equality

### DIFF
--- a/src/utils/hlir.py
+++ b/src/utils/hlir.py
@@ -42,11 +42,11 @@ def format_p4_node(node):
         return "if (%s) { %s } else { %s }" % (format_expr(node.condition), format_p4_node(node.next_[True]), format_p4_node(node.next_[False]))
 
 def format_op(op):
-    if op is "not":
+    if op == "not":
         return "!"
-    elif op is "and":
+    elif op == "and":
         return "&&"
-    elif op is "or":
+    elif op == "or":
         return "||"
     else:
         return str(op)


### PR DESCRIPTION
Current code might generate invalid c ('and' instead of '&&').
See string interning: 
https://en.wikipedia.org/wiki/String_interning
https://stackoverflow.com/a/2988117

Credit: @jnaab