### PR TITLE
Fix unexpected behaviour due to mbuf_table overflow on dpdk-nicon tx

### DIFF
--- a/src/hardware_dep/dpdk/includes/dpdk_lib.h
+++ b/src/hardware_dep/dpdk/includes/dpdk_lib.h
@@ -72,9 +72,11 @@
 
 #define MAX_JUMBO_PKT_LEN  9600
 
+#define MBUF_TABLE_SIZE 32
+
 struct mbuf_table {
 	uint16_t len;
-	struct rte_mbuf *m_table[];
+	struct rte_mbuf *m_table[MBUF_TABLE_SIZE];
 };
 
 #define RTE_TEST_RX_DESC_DEFAULT 128

--- a/src/hardware_dep/dpdk/includes/dpdk_nicon.h
+++ b/src/hardware_dep/dpdk/includes/dpdk_nicon.h
@@ -23,7 +23,7 @@
 
 #define T4P4S_BROADCAST_PORT    100
 
-#define MAX_PKT_BURST     32
+#define MAX_PKT_BURST     32  /* note: this equals to MBUF_TABLE_SIZE in dpdk_lib.h */
 #define BURST_TX_DRAIN_US 100 /* TX drain every ~100us */
 
 #define MAX_PORTS               16


### PR DESCRIPTION
Note:
- `variant=test` cannot find this as it does not put any packet on the table.
- it's safe to set `MAX_PKT_BURST` to `MBUF_TABLE_SIZE` in current dpdk_nicon use.

Please review, thanks.