### PR TITLE
Flush data plane stateful memories in between multiple launches

### DIFF
--- a/src/hardware_dep/dpdk/data_plane/dpdk_tables.c
+++ b/src/hardware_dep/dpdk/data_plane/dpdk_tables.c
@@ -146,6 +146,24 @@ void create_table(lookup_table_t* t, int socketid)
     debug("    : Created table replica " T4LIT(%s,table) ".\n", t->name);
 }
 
+void flush_table(lookup_table_t* t)
+{
+    if (t->entry.key_size == 0) return; // must be a fake table
+
+    switch(t->type)
+    {
+        case LOOKUP_EXACT:
+            exact_flush(t);
+            break;
+        case LOOKUP_LPM:
+            lpm_flush(t);
+            break;
+        case LOOKUP_TERNARY:
+            ternary_flush(t);
+            break;
+    }
+    debug("    : Flushed table replica " T4LIT(%s,table) ".\n", t->name);
+}
 
 void table_set_default_action(lookup_table_t* t, uint8_t* entry)
 {

--- a/src/hardware_dep/dpdk/data_plane/dpdk_tables_lpm.c
+++ b/src/hardware_dep/dpdk/data_plane/dpdk_tables_lpm.c
@@ -135,3 +135,18 @@ uint8_t* lpm_lookup(lookup_table_t* t, uint8_t* key)
     }
     return NULL;
 }
+
+
+void lpm_flush(lookup_table_t* t)
+{
+    extended_table_t* ext = (extended_table_t*)t->table;
+    rte_free(ext->content[ext->size]);
+    if (t->entry.key_size <= 4)
+    {
+        rte_lpm_delete_all(ext->rte_table);
+    }
+    else if (t->entry.key_size <= 16)
+    {
+        rte_lpm6_delete_all(ext->rte_table);
+    }
+}

--- a/src/hardware_dep/dpdk/data_plane/dpdk_tables_ternary.c
+++ b/src/hardware_dep/dpdk/data_plane/dpdk_tables_ternary.c
@@ -35,3 +35,10 @@ uint8_t* ternary_lookup(lookup_table_t* t, uint8_t* key)
     uint8_t* ret = naive_ternary_lookup(t->table, key);
     return ret == NULL ? t->default_val : ret;
 }
+
+void ternary_flush(lookup_table_t* t)
+{
+    if (t->entry.key_size == 0) return; // nothing must have been added
+
+    naive_ternary_flush(t->table);
+}

--- a/src/hardware_dep/dpdk/main.c
+++ b/src/hardware_dep/dpdk/main.c
@@ -54,6 +54,8 @@ extern void initialize_nic();
 extern int init_tables();
 extern int init_memories();
 
+extern int flush_tables();
+
 extern int launch_count();
 extern void t4p4s_abnormal_exit(int retval, int idx);
 extern void t4p4s_pre_launch(int idx);
@@ -247,6 +249,8 @@ int main(int argc, char** argv)
         }
 
         t4p4s_post_launch(i);
+
+        flush_tables();
     }
 
     t4p4s_normal_exit();

--- a/src/hardware_dep/shared/data_plane/ternary_naive.c
+++ b/src/hardware_dep/shared/data_plane/ternary_naive.c
@@ -65,3 +65,13 @@ naive_ternary_lookup(ternary_table* t, uint8_t* key)
     return match ? res->value : NULL;
 }
 
+void
+naive_ternary_flush(ternary_table* t)
+{
+    int i;
+    for(i = t->size - 1; i >= 0; i--)
+    {
+        free(t->entries[i]);
+        t->size--;
+    }
+}

--- a/src/hardware_dep/shared/includes/ternary_naive.h
+++ b/src/hardware_dep/shared/includes/ternary_naive.h
@@ -34,5 +34,6 @@ ternary_table* naive_ternary_create (uint8_t keylen, uint8_t max_size);
 void           naive_ternary_destroy(ternary_table* t);
 void           naive_ternary_add    (ternary_table* t, uint8_t* key, uint8_t* mask, uint8_t* value);
 uint8_t*       naive_ternary_lookup (ternary_table* t, uint8_t* key);
+void           naive_ternary_flush  (ternary_table* t);
 
 #endif


### PR DESCRIPTION
**What this PR does / why we need it**:
Flush data plane tables betweem each launch.
- At present this equals to the case where `defined(T4P4S_TEST_SUITE)` and `launch_count()` > 0.
- Without this, mac_learn-ed entries added in a testcase would affect subsequent testcases.

Please review, thanks.