### PR TITLE
[RFC] Simple implementation to synchronize control plane init table manipulations

### DIFF
--- a/src/hardware_dep/shared/ctrl_plane/ctrl_plane_backend.c
+++ b/src/hardware_dep/shared/ctrl_plane/ctrl_plane_backend.c
@@ -237,6 +237,7 @@ ctrl_plane_backend create_backend(int num_of_threads, int queue_size, char* cont
 void launch_backend(ctrl_plane_backend bg)
 {
 	backend_t *bgt = (backend_t*) bg;
+	ctrl_is_initialized = 0;
 
         if( connect( bgt->controller_sock, (struct sockaddr *) &(bgt->controller_addr), sizeof(struct sockaddr_in) ) == -1 )
         {
@@ -250,6 +251,9 @@ void launch_backend(ctrl_plane_backend bg)
         dispatch(bgt->tpool, input_processor, (void*)bgt);
 					sleep(1);
         dispatch(bgt->tpool, output_processor, (void*)bgt);
+
+        while (!ctrl_is_initialized)
+            sleep(1);
 }
 
 void stop_backend(ctrl_plane_backend bg)

--- a/src/hardware_dep/shared/ctrl_plane/ctrl_plane_backend.h
+++ b/src/hardware_dep/shared/ctrl_plane/ctrl_plane_backend.h
@@ -30,5 +30,6 @@ void stop_backend(ctrl_plane_backend bg);
 ctrl_plane_digest create_digest(ctrl_plane_backend bg, char* name);
 ctrl_plane_digest add_digest_field(ctrl_plane_digest d, void* value, uint32_t length);
 
+volatile int ctrl_is_initialized;
 
 #endif

--- a/src/hardware_dep/shared/ctrl_plane/dpdk_l2fwd_controller.c
+++ b/src/hardware_dep/shared/ctrl_plane/dpdk_l2fwd_controller.c
@@ -22,6 +22,19 @@
 
 controller c;
 
+void notify_controller_initialized()
+{
+        char buffer[sizeof(struct p4_header)];
+        struct p4_header* h;
+
+        h = create_p4_header(buffer, 0, sizeof(struct p4_header));
+        h->type = P4T_CTRL_INITIALIZED;
+
+        netconv_p4_header(h);
+
+        send_p4_msg(c, buffer, sizeof(struct p4_header));
+}
+
 void fill_smac_table(uint8_t port, uint8_t mac[6])
 {
         char buffer[2048];
@@ -281,6 +294,7 @@ void init() {
                 fill_smac_table(portmap[i], macs[i]);
         }
 
+        notify_controller_initialized();
 }
 
 

--- a/src/hardware_dep/shared/ctrl_plane/handlers.h
+++ b/src/hardware_dep/shared/ctrl_plane/handlers.h
@@ -34,6 +34,7 @@ struct p4_ctrl_msg {
 typedef void (*p4_msg_callback)(struct p4_ctrl_msg*);
 
 int handle_p4_msg(char* buffer, int length, p4_msg_callback cb);
+int handle_p4_ctrl_initialized(struct p4_header* header, struct p4_ctrl_msg* ctrl_m);
 int handle_p4_set_default_action(struct p4_set_default_action* m, struct p4_ctrl_msg* ctrl_m);
 int handle_p4_add_table_entry(struct p4_add_table_entry* m, struct p4_ctrl_msg* ctrl_m);
 

--- a/src/hardware_dep/shared/ctrl_plane/messages.h
+++ b/src/hardware_dep/shared/ctrl_plane/messages.h
@@ -36,6 +36,7 @@ enum p4_type {
 	P4T_ECHO_REQUEST = 2,
 	P4T_ECHO_REPLY = 3,
 	P4T_SUCCESS = 4,
+	P4T_CTRL_INITIALIZED = 5,
 
 	/* Switch informations */	
 	P4T_GET_TABLE_DEFINITIONS = 100,

--- a/src/hardware_dep/shared/ctrl_plane/sock_helpers.c
+++ b/src/hardware_dep/shared/ctrl_plane/sock_helpers.c
@@ -59,6 +59,9 @@ int read_p4_msg(int sock, char* buffer, int length)
 	if (msglen>length)
 		return -100;
 
+	if (msglen == sizeof(struct p4_header))
+		return msglen;
+
 	if ((rval=read_fix(sock, buffer + sizeof(struct p4_header), msglen-sizeof(struct p4_header)))<=0)
 		return rval;
 	return msglen;

--- a/src/hardware_indep/controlplane.c.py
+++ b/src/hardware_indep/controlplane.c.py
@@ -214,11 +214,20 @@ for table in hlir16_tables_with_keys:
 #} }
 
 
+#[ extern volatile int ctrl_is_initialized;
+#{ void ctrl_initialized() {
+#[     debug("Control plane fully initialized.\n");
+#[     ctrl_is_initialized = 1;
+#} }
+
+
 #{ void recv_from_controller(struct p4_ctrl_msg* ctrl_m) {
 #{     if (ctrl_m->type == P4T_ADD_TABLE_ENTRY) {
 #[          ctrl_add_table_entry(ctrl_m);
 #[     } else if (ctrl_m->type == P4T_SET_DEFAULT_ACTION) {
 #[         ctrl_setdefault(ctrl_m);
+#[     } else if (ctrl_m->type == P4T_CTRL_INITIALIZED) {
+#[         ctrl_initialized();
 #}     }
 #} }
 


### PR DESCRIPTION
**What this PR does / why we need it:**
Having data plane wait for the initial table manipulations done by control plane, we can get rid of the race between handling first arriving packets and installing default actions + user-defined portmaps.

This is quite naive implementation using global var `ctrl_is_initialized` just to make it simple and clarify the idea. If you would agree with the synchronization idea but not much for `ctrl_is_initialized`, please let me hear your suggestion.

Please review, thanks.