### PR TITLE
bugfix: fix undefined lcore_id

### DIFF
--- a/src/hardware_dep/dpdk/main.c
+++ b/src/hardware_dep/dpdk/main.c
@@ -190,7 +190,7 @@ bool initial_check(LCPARAMS) {
 
     #ifdef START_CRYPTO_NODE
         if (is_crypto_node()){
-            RTE_LOG(INFO, P4_FWD, "lcore %u is the crypto node\n", lcore_id);
+            RTE_LOG(INFO, P4_FWD, "lcore %u is the crypto node\n", rte_lcore_id());
         }
     #endif
 


### PR DESCRIPTION
In commit 721c576 the `RTE_LOG()` call was moved out of `dpdk_main_loop()` into `initial_check()`, however, the variable `lcore_id` is not declared in the scope of this function.