### PR TITLE
shifting in bitmasks

### DIFF
--- a/src/hardware_dep/dpdk/includes/dpdk_primitives_impl.h
+++ b/src/hardware_dep/dpdk/includes/dpdk_primitives_impl.h
@@ -44,7 +44,7 @@
 /******************************************************************************/
 
 #define FLD_MASK(fd) (fd.fixed_width ? fd.mask : \
-    rte_cpu_to_be_32((~0 << (32 - fd.bitcount)) & (~0 >> fd.bitoffset)))
+    rte_cpu_to_be_32((~0U << (32 - fd.bitcount)) & (~0U >> fd.bitoffset)))
 
 #define FLD_BYTES(fd) (  fd.bytecount == 1 ? (*(uint8_t*)  fd.byte_addr) : \
                          ( fd.bytecount == 2 ? (*(uint16_t*) fd.byte_addr) : \
@@ -55,7 +55,7 @@
 #define BYTECOUNT(fd)  ((fd.bitcount - 1) / 8)
 
 #define MASK_LOW(fd) (FLD_MASK(fd) & 0xff)
-#define MASK_MID(fd) (FLD_MASK(fd) & (~0 >> ((4 - BYTECOUNT(fd)) * 8)) & ~0xff)
+#define MASK_MID(fd) (FLD_MASK(fd) & (~0U >> ((4 - BYTECOUNT(fd)) * 8)) & ~0xff)
 #define MASK_TOP(fd) (FLD_MASK(fd) & (0xff << (BYTECOUNT(fd) * 8)))
 
 /*******************************************************************************


### PR DESCRIPTION
Hi,

I have some problems when bitmasks are used to get data out of packets.

The problem is that shifting a signed/negative number is compiler-dependent. Some compilers perform an arithmetic shift if the value is signed/negative. ~0 can be interpreted as negative since the first bit is set. Then the shift is performed, filling up with 1 bits.

Standard C99 §6.5.7:
```
The result of E1 >> E2 is E1 right-shifted E2 bit positions. If E1 has an unsigned type
or if E1 has a signed type and a nonnegative value, the value of the result is the integral
part  of  the  quotient  of E1 / 2 E2. If E1 has  a  signed  type  and  a  negative  value,  the
resulting value is implementation-defined.
```

What we need in the masks are logical shifts. These are performed if the value is positive/unsigned. This should be ensured declaring the 0 as an unsigned literal.
`~0` -> `~0U`


